### PR TITLE
Adapt for lightweight interface

### DIFF
--- a/robots/iiwa.urdf.xacro
+++ b/robots/iiwa.urdf.xacro
@@ -2,8 +2,9 @@
 <robot name="iiwa7" xmlns:xacro="http://www.ros.org/wiki/xacro">
   <xacro:arg name="robot" default="iiwa7"/>
   <xacro:arg name="prefix" default="$(arg robot)_"/>
-  <xacro:arg name="robot_ip" default="192.170.10.1"/>
-  <xacro:arg name="port" default="30200"/>
+  <xacro:arg name="robot_ip" default="127.0.0.1"/>
+  <xacro:arg name="robot_state_port" default="9701"/>
+  <xacro:arg name="robot_command_port" default="9702"/>
   <xacro:arg name="load_ros2_control" default="false"/>
   <xacro:arg name="use_sim" default="false"/>
   <xacro:arg name="connected_to" default=""/>
@@ -26,6 +27,7 @@
   <xacro:if value="$(arg load_ros2_control)">
     <xacro:include filename="$(find kuka_iiwa_description)/ros2_control/iiwa.ros2_control.xacro"/>
     <xacro:iiwa_interface name="IiwaInterface" prefix="$(arg prefix)" robot_ip="$(arg robot_ip)"
-                          port="$(arg port)" use_sim="$(arg use_sim)"/>
+                          robot_state_port="$(arg robot_state_port)" robot_command_port="$(arg robot_command_port)"
+                          use_sim="$(arg use_sim)"/>
   </xacro:if>
 </robot>

--- a/ros2_control/iiwa.ros2_control.xacro
+++ b/ros2_control/iiwa.ros2_control.xacro
@@ -3,6 +3,14 @@
   <xacro:macro name="iiwa_interface" params="name prefix robot_ip robot_state_port robot_command_port use_sim">
 
     <ros2_control name="${name}" type="system">
+      <xacro:if value="${use_sim}">
+        <hardware>
+          <plugin>robot_interface/simulators/PybulletInterface</plugin>
+          <param name="robot_ip">${robot_ip}</param>
+          <param name="robot_state_port">${robot_state_port}</param>
+          <param name="robot_command_port">${robot_command_port}</param>
+        </hardware>
+      </xacro:if>
       <xacro:unless value="${use_sim}">
         <hardware>
           <plugin>robot_interface/kuka/IiwaInterface</plugin>

--- a/ros2_control/iiwa.ros2_control.xacro
+++ b/ros2_control/iiwa.ros2_control.xacro
@@ -1,13 +1,14 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
-  <xacro:macro name="iiwa_interface" params="name prefix robot_ip port use_sim">
+  <xacro:macro name="iiwa_interface" params="name prefix robot_ip robot_state_port robot_command_port use_sim">
 
     <ros2_control name="${name}" type="system">
       <xacro:unless value="${use_sim}">
         <hardware>
           <plugin>robot_interface/kuka/IiwaInterface</plugin>
           <param name="robot_ip">${robot_ip}</param>
-          <param name="port">${port}</param>
+          <param name="robot_state_port">${robot_state_port}</param>
+          <param name="robot_command_port">${robot_command_port}</param>
         </hardware>
       </xacro:unless>
 


### PR DESCRIPTION
Same as in franka panda description, use robot_ip, robot_state_port and robot_command port to set up the zmq sockets