### PR TITLE
Add velocity state interface

### DIFF
--- a/ros2_control/iiwa.ros2_control.xacro
+++ b/ros2_control/iiwa.ros2_control.xacro
@@ -30,6 +30,7 @@
           <param name="max">${max_effort_1}</param>
         </command_interface>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
         <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint2">
@@ -42,6 +43,7 @@
           <param name="max">${max_effort_2}</param>
         </command_interface>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
         <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint3">
@@ -54,6 +56,7 @@
           <param name="max">${max_effort_3}</param>
         </command_interface>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
         <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint4">
@@ -66,6 +69,7 @@
           <param name="max">${max_effort_4}</param>
         </command_interface>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
         <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint5">
@@ -78,6 +82,7 @@
           <param name="max">${max_effort_5}</param>
         </command_interface>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
         <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint6">
@@ -90,6 +95,7 @@
           <param name="max">${max_effort_6}</param>
         </command_interface>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
         <state_interface name="effort"/>
       </joint>
       <joint name="${prefix}joint7">
@@ -102,6 +108,7 @@
           <param name="max">${max_effort_7}</param>
         </command_interface>
         <state_interface name="position"/>
+        <state_interface name="velocity"/>
         <state_interface name="effort"/>
       </joint>
 


### PR DESCRIPTION
* Using the Kuka Lightweight Interface, the joint velocity is now estimated
and available as a state interface